### PR TITLE
Add pscale CLI automation skill

### DIFF
--- a/09-mcp-agent-operating-model/SKILL.md
+++ b/09-mcp-agent-operating-model/SKILL.md
@@ -19,7 +19,19 @@ The full MCP server has query execution tools. Treat write query tools as disabl
 
 ## AGENTS.md guidance
 
-When working inside a repository, recommend adding a database targeting section to `AGENTS.md` or equivalent project instructions:
+Two different documents both named `AGENTS.md` serve different purposes:
+
+1. **CLI agent guide** — shipped with `pscale` (`AGENTS.md` in the
+   [planetscale/cli](https://github.com/planetscale/cli) repo, or
+   `pscale agent-guide --format json`). Covers auth, `--format json`, flag
+   placement, and `pscale sql`. Load skill `14-pscale-cli-automation` for the
+   same conventions inside this skills pack.
+
+2. **Project agent guide** — your application repository's `AGENTS.md` (or
+   equivalent). Covers database targeting and approval policy for *this* app.
+
+When working inside a repository, recommend adding a **project** database
+targeting section to `AGENTS.md` or equivalent project instructions:
 
 - PlanetScale organization.
 - Database.

--- a/14-pscale-cli-automation/SKILL.md
+++ b/14-pscale-cli-automation/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: planetscale-pscale-cli-automation
+description: >-
+  Use the PlanetScale CLI (pscale) from automated agents with --format json,
+  auth check, pscale sql, and per-command --force. Run before other PlanetScale
+  skills when driving pscale directly. Use when the user asks to automate
+  pscale, run CLI commands headless, or verify pscale auth from an agent.
+---
+
+# PlanetScale CLI automation
+
+## Purpose
+
+Teach agents how to invoke `pscale` non-interactively. This skill covers **CLI
+conventions only**. Operational workflows (inventory, safety review, schema
+recommendations) use the other skills in this repo — start with
+`../00-safe-orchestrator/SKILL.md` for a full assessment.
+
+## Two AGENTS.md files (do not confuse them)
+
+| Document | Where | Purpose |
+|----------|-------|---------|
+| **CLI agent guide** | Shipped with `pscale` (`AGENTS.md` in the CLI repo, or `pscale agent-guide`) | How to call `pscale`: auth, `--format json`, flag placement, `pscale sql` |
+| **Project agent guide** | Your application repository's `AGENTS.md` | Which org, database, branch, engine, prod branch, MCP scope, approval rules |
+
+Do not edit project `AGENTS.md` without operator approval (see
+`../09-mcp-agent-operating-model/SKILL.md`).
+
+## Bootstrap (always start here)
+
+```bash
+pscale agent-guide --format json
+pscale auth check --format json
+```
+
+If `auth check` returns `"status": "action_required"`, follow `issues` and
+`next_steps` in the JSON. For login, the human may need to approve in the
+browser; use `pscale auth login --format json`.
+
+## Conventions
+
+- Always pass **`--format json`** for automation.
+- Put **`--org <org>`** on resource subcommands (`database`, `branch`, `sql`,
+  `api`, …) — not on root `pscale`.
+- Put **positional arguments before flags** (`pscale sql mydb main --org bb …`).
+- Use **`pscale sql`**, not `pscale shell` (shell requires a TTY).
+- Default SQL role is **reader**; pass `--role admin` (or writer/readwriter) for
+  writes. Match `pscale shell` semantics for `--role` and `--replica`.
+- **`--force`** is per subcommand only (e.g. `database delete … --force`, `pscale
+  sql … --force`). There is no global `--force` or `PSCALE_FORCE`.
+- **`--format json` alone never skips confirmations** — add `--force` on the
+  destructive subcommand after explicit user approval.
+
+## Typical workflow
+
+```bash
+pscale auth check --format json
+pscale org list --format json
+pscale database list --org <org> --format json
+pscale branch list <database> --org <org> --format json
+pscale sql <database> <branch> --org <org> --format json --query "SELECT 1"
+```
+
+MySQL uses `@primary` by default (same as `pscale shell`); pass `--keyspace` only
+for multi-keyspace databases.
+
+## MCP vs CLI
+
+- **MCP clients** — use the hosted PlanetScale MCP server (see `pscale agent-guide
+  --format json` for the current URL).
+- **Shell scripts and coding agents** — use `pscale` with `--format json` as above.
+
+## When this skill is not enough
+
+Install the full PlanetScale skills pack (if not already):
+
+```sh
+git clone https://github.com/planetscale/skills.git && cd skills && script/setup
+# or: npx skills add planetscale/skills -g -y
+```
+
+Then run sub-skills or `../00-safe-orchestrator/SKILL.md` for database operations
+beyond basic CLI invocation.
+
+## Current conventions source of truth
+
+Prefer live output over memorized flag syntax:
+
+```bash
+pscale agent-guide --format json
+```
+
+The embedded `guide` field contains the full CLI agent guide shipped with your
+`pscale` binary.

--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ agent-specific: no plugins, no custom tools, no proprietary rendering.
 
 ### Prerequisites
 
-1. **PlanetScale CLI**, authenticated:
+1. **PlanetScale CLI**, authenticated for automation:
 
    ```sh
    brew install planetscale/tap/pscale   # or see planetscale.com/cli
-   pscale auth login
-   pscale org list                       # verify access
+   pscale agent-guide --format json      # CLI conventions (or load skill 14-pscale-cli-automation)
+   pscale auth check --format json       # verify auth; follow next_steps if action_required
+   pscale org list --format json         # verify access
    ```
+
+   Agents should always pass `--format json` on `pscale` commands. Use `pscale sql`
+   for non-interactive queries, not `pscale shell`. See skill `14-pscale-cli-automation`
+   or the CLI repo `AGENTS.md` for full conventions.
 
 2. **Optional: PlanetScale MCP server.** The skills prefer the
    insights-only MCP server for telemetry analysis when it is available,


### PR DESCRIPTION
## Summary

Integrates the PlanetScale skills pack with the agent-friendly `pscale` CLI work (see planetscale/cli#1280).

- **`14-pscale-cli-automation`** — new skill for headless `pscale` usage: `--format json`, `auth check`, `pscale sql`, per-command `--force`, and CLI vs project `AGENTS.md` separation. Points to `pscale agent-guide --format json` as the live source of truth.
- **`README.md`** — prerequisites use `agent-guide` / `auth check --format json` instead of human-only login flow.
- **`09-mcp-agent-operating-model`** — clarifies that CLI `AGENTS.md` (pscale invocation) is separate from project `AGENTS.md` (org/database/branch targeting).

## Agent flow

```text
pscale agent-guide --format json   # CLI conventions (cli repo)
script/setup                       # install this skills pack
14-pscale-cli-automation           # CLI automation in skills
00-safe-orchestrator               # full database assessment
project AGENTS.md                  # org/db/branch + approval rules
```

## Test plan

- [ ] `script/setup` picks up `14-pscale-cli-automation/` (numbered directory)
- [ ] Skill frontmatter `name` resolves to `planetscale-pscale-cli-automation`
- [ ] README prerequisite commands match shipped CLI agent onboarding (once cli#1280 merges)

## Related

- https://github.com/planetscale/cli/pull/1280