### PR TITLE
Update skills for the public Query Insights API

### DIFF
--- a/01-readonly-inventory/SKILL.md
+++ b/01-readonly-inventory/SKILL.md
@@ -63,8 +63,14 @@ Verified interface notes (recheck against the docs when a command fails):
   session inventory works for Postgres and Vitess over a reserved
   administrative connection. Do not cancel queries or terminate connections
   unless the operator explicitly approves that operational action.
-- Live query telemetry: `.../branches/{branch}/insights`. Anomalies:
-  `.../branches/{branch}/insights/anomalies`. The `query-patterns` path
+- Query Insights is public API. Live query telemetry:
+  `.../branches/{branch}/insights` (per-pattern statistics; supports
+  `from`/`to`/`period`, `q`, `sort`, `dir`, `tablet_type`, `type`,
+  `fields`, and pagination). Related endpoints under the same branch path:
+  `insights/errors`, `insights/anomalies`, `insights/tags`,
+  `insights/tags/summaries`, `insights/{fingerprint}` (individual
+  executions), `insights/{fingerprint}/summary`, and
+  `insights/{fingerprint}/traffic/budgets`. The `query-patterns` path
   returns generated report metadata, not live patterns.
 - Traffic budgets: `.../branches/{branch}/traffic/budgets`. The CLI has no
   `pscale traffic-control budget list`; use the API for inventory.

--- a/02-vitess-safety-review/SKILL.md
+++ b/02-vitess-safety-review/SKILL.md
@@ -82,8 +82,9 @@ Review Insights for:
   vindex usage changes after index or routing changes.
 - Unusual query volume.
 - Missing SQL comment tags.
-- Tag breakdowns and `tag:key:value` filtering when Query Insights exposes
-  built-in metadata or SQLCommenter tags.
+- Tag breakdowns when built-in metadata or SQLCommenter tags are present:
+  `tag:key:value` filtering in the dashboard, and the `insights/tags` and
+  `insights/tags/summaries` API endpoints for programmatic breakdowns.
 - Deploy correlation data.
 
 Recommend enabling or improving application query tagging so Insights can attribute queries to app, route, controller, action, job, deployment SHA, and feature.

--- a/03-postgres-safety-review/SKILL.md
+++ b/03-postgres-safety-review/SKILL.md
@@ -69,8 +69,8 @@ Review:
 
 - Slow queries.
 - High rows-read queries.
-- High CPU query patterns when MCP or API Insights exposes CPU-sorted Postgres
-  data.
+- High CPU query patterns (`sort=cpuTime` or `sort=percentCpuTime` on the
+  Insights API).
 - High-frequency queries.
 - Erroring queries.
 - Active anomalies.

--- a/04-query-insights-and-tags/SKILL.md
+++ b/04-query-insights-and-tags/SKILL.md
@@ -19,23 +19,68 @@ For the selected database and branch, inspect:
 - Top queries by time per execution.
 - Top queries by rows read.
 - Top queries by execution count.
-- For Postgres, top queries by CPU usage when the MCP/API surface exposes
-  CPU-sorted Insights data.
+- For Postgres, top queries by CPU usage (`sort=cpuTime` or
+  `sort=percentCpuTime` on the Insights API).
 - Queries with errors.
 - Notable queries and active anomalies.
 - Query patterns affected by recent deploys.
 - Query patterns attached to schema recommendations.
 - For sharded Vitess databases, vindex usage for each query pattern: the
   percentage of traffic using relevant vindexes and the vindex-usage trend
-  over time. Treat missing or declining relevant-vindex usage as an indexing
-  or routing investigation input, not as proof that a new index is required.
+  over time. The API exposes per-pattern `index_usages` and
+  `routing_index_usages`; get the trend from the dashboard Vindexes tab or
+  by comparing API windows. Treat missing or declining relevant-vindex
+  usage as an indexing or routing investigation input, not as proof that a
+  new index is required.
 
-The Insights API (`.../branches/{branch}/insights`) returns hourly
-pattern snapshots. Duration aggregates use field names like
-`sum_total_duration_millis` — not `total_time_millis`. When the
-aggregation window is not explicit in the response, time-share
-percentages within the returned window are more reliable than absolute
-duration totals; prefer them for ranking.
+### Insights API surface
+
+Query Insights is public API: read-only GET endpoints under
+`organizations/{org}/databases/{db}/branches/{branch}`, authorized by a
+service token or OAuth token with `read_databases`/`read_database`.
+
+- `/insights` — aggregated statistics per query pattern over the requested
+  window. Set the window with `from`/`to` (ISO 8601) or `period` (for
+  example `1h`, `24h`); search SQL patterns with `q`; sort server-side with
+  `sort` and `dir` — sort keys include `count`, `errorCount`, `rowsRead`,
+  `totalTime`, `cpuTime`, `ioTime`, `percentTime`, `percentCpuTime`,
+  `p50Latency`, `p99Latency`, `maxLatency`, `egressBytes`, and the
+  `trafficControlWarnings`/`trafficControlThrottled` family. Filter with
+  `tablet_type` (`primary`, `replica`, `rdonly`) and `type` (`SELECT`,
+  `INSERT`, `UPDATE`, `DELETE`); trim responses with `fields`; paginate
+  with `page`/`per_page`.
+- `/insights/{fingerprint}` — individual collected executions for a
+  pattern (timestamps, duration, rows, username, client address, error
+  message). Available regardless of raw query collection; raw collection
+  adds literal parameter values to these records.
+  `/insights/{fingerprint}/summary` returns the single-pattern aggregate;
+  `/insights/queries/{id}` fetches one execution.
+- `/insights/errors` — error fingerprints with counts and messages (`q`
+  searches the error message; sort by `count`, `lastRun`, `totalTime`, or
+  `timePerQuery`). `/insights/errors/{fingerprint}` lists the failing
+  executions behind one error fingerprint.
+- `/insights/anomalies` and `/insights/anomalies/{id}` — anomaly windows
+  with per-query correlation coefficients identifying which patterns moved
+  with the anomaly.
+- `/insights/tags` — tag keys with observed values (`values_limit`,
+  `literal_values_only`, and `fingerprint`/`keyspace` filters);
+  `/insights/tags/{tag}` for a single key. `/insights/tags/summaries`
+  groups the full statistics schema by one or more tag keys via the `tags`
+  parameter — use it to attribute load to routes, jobs, or features
+  without client-side aggregation.
+- `/insights/{fingerprint}/traffic/budgets` — the Traffic Control budgets
+  and rules that affect a fingerprint (Postgres).
+
+Aggregates cover the requested window. Duration fields use names like
+`sum_total_duration_millis`, with explicit share-of-window percent fields
+(`sum_total_duration_percent`); both totals and percentages are reliable
+for the window requested.
+
+The response schema is shared across engines, but some fields are
+engine-specific: CPU/IO durations and block-cache statistics
+(`sum_cpu_duration_millis`, `blocks_read`, `block_cache_hit_ratio`, …) are
+populated for Postgres; shard queries, keyspaces, `tablet_type`, and
+routing-index (vindex) usage are populated for Vitess.
 
 ### Tag coverage
 
@@ -47,11 +92,12 @@ For each expensive or anomalous query, determine:
 - Which deployment SHA produced it?
 - Is the tag cardinality safe?
 - Are tags consistent across frameworks and languages?
-- For Vitess, use Query Insights tag filtering and navigation when available:
-  filter the query table with `tag:key:value`, inspect the Tags view for
-  breakdowns, and drill into query details to see tags attached to individual
-  executions. Built-in query metadata and SQLCommenter tags are both valid
-  attribution sources.
+- Use the tags API to answer these questions: `/insights/tags` shows which
+  keys and values are present, and `/insights/tags/summaries?tags=...`
+  attributes load per tag value. In the Vitess dashboard, filter the query
+  table with `tag:key:value` and drill into query details to see tags on
+  individual executions. Built-in query metadata and SQLCommenter tags are
+  both valid attribution sources.
 
 ### Raw query collection
 
@@ -67,7 +113,9 @@ is the effective state.
 Report it as a capability state, not a risk posture. Raw query collection
 records literal parameter values per execution, which pattern-level Insights
 data does not provide. It is the mechanism for isolating which specific
-invocation of a pattern is pathological.
+invocation of a pattern is pathological. Execution-level records are
+retrievable from `/insights/{fingerprint}` with or without raw collection;
+raw collection adds the literal parameter values to those records.
 
 When it is disabled, the finding is a capability gap: identify the query
 patterns in this assessment where pattern-level data is insufficient

--- a/09-mcp-agent-operating-model/SKILL.md
+++ b/09-mcp-agent-operating-model/SKILL.md
@@ -196,9 +196,10 @@ For read queries:
   rows or a zero count and the MCP response warns that RLS may be filtering
   results, treat the result as policy-filtered/unknown until confirmed through
   an approved path; do not conclude the table is empty.
-- When debugging high CPU on Postgres, use MCP Insights data sorted by CPU
-  usage where available. CPU time metrics are Postgres-only in that tool; do
-  not ask for the same CPU-sorted view on Vitess.
+- When debugging high CPU on Postgres, use Insights data sorted by CPU
+  usage (via MCP where available, or `sort=cpuTime` on the Insights API).
+  CPU time metrics are Postgres-only; do not ask for the same CPU-sorted
+  view on Vitess.
 
 For write queries:
 

--- a/12-best-practices-matrix/SKILL.md
+++ b/12-best-practices-matrix/SKILL.md
@@ -16,13 +16,16 @@ Map database findings to recommended PlanetScale features. Use this to ensure th
 Recommend for every production database:
 
 - Review slow, expensive, high-frequency, and erroring query patterns.
-- For Postgres, use CPU-sorted Insights data when diagnosing CPU pressure.
+- For Postgres, sort Insights by CPU (`sort=cpuTime` on the Insights API)
+  when diagnosing CPU pressure.
 - For sharded Vitess, review vindex usage per query pattern and the usage
   trend after index or routing changes.
 - Correlate regressions with deploys.
 - Use tags/comments to map queries back to code.
-- Use tag filtering/navigation in Vitess Query Insights where available
-  (`tag:key:value`, Tags view, and per-execution tag drill-down).
+- Use tag filtering/navigation in Query Insights: the tags API
+  (`insights/tags`, `insights/tags/summaries`) on both engines, plus
+  `tag:key:value` filtering and per-execution tag drill-down in the Vitess
+  dashboard.
 - Use anomalies as alert and automation inputs.
 
 ### Webhooks


### PR DESCRIPTION
The Query Insights endpoints are now part of the public PlanetScale API. Document the full endpoint surface and parameters (window, search, sort, filters, tags group-by, per-fingerprint executions, errors, anomalies, traffic budgets), drop the obsolete hourly-snapshot caveat, replace hedged "when available" CPU-sort language with the actual sort parameters, and note which response fields are Postgres- vs Vitess-populated.